### PR TITLE
adding support for other object types

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,35 @@
-Object.values = Object.values ? Object.values : function(obj) {
-    var objType = Object.prototype.toString.call(obj);
-    if(objType === "[object Array]" || objType === "[object Object]") {
-        var valuesArray = [];
-        for(var key in obj) {
-            valuesArray.push(obj[key]);
-        }
-        
-        return objType === "[object Array]" ? valuesArray : valuesArray.sort(function(a, b) {return a-b;});
+Object.values =  function(obj) {
+    // if ES6 is supported
+    if (Object.keys) {
+        return Object.keys(object).map(function (key) {
+	        return object[key];
+	    });
     }
-    else {
-        if(obj === null || typeof obj === "undefined") {
-            throw new TypeError("Cannot convert undefined or null to object");
-        }
-        else {
-            return [];
+    var hasOwnProperty = Object.prototype.hasOwnProperty,
+        hasDontEnumBug = !({toString: null}).propertyIsEnumerable('toString'),
+        dontEnums = [
+          'toString',
+          'toLocaleString',
+          'valueOf',
+          'hasOwnProperty',
+          'isPrototypeOf',
+          'propertyIsEnumerable',
+          'constructor'
+        ],
+        dontEnumsLength = dontEnums.length;
+    
+    if (typeof obj !== 'object' && typeof obj !== 'function' || obj === null) throw new TypeError('Object.values called on non-object');
+ 
+    var result = [];
+ 
+    for (var prop in obj) {
+        if (hasOwnProperty.call(obj, prop)) result.push(obj[prop]);
+    }
+ 
+    if (hasDontEnumBug) {
+        for (var i=0; i < dontEnumsLength; i++) {
+            if (hasOwnProperty.call(obj, dontEnums[i])) result.push(obj[dontEnums[i]]);
         }
     }
+    return result;
 };
-
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = Object.entries;
-}


### PR DESCRIPTION
I have noticed that the current implementation doesn't support string object, Array object,,,etc.
for example:

`Object.prototype.toString.call(new String('test!'))` returns `"[object String]"`
and in that case this polyfill will return `[]`, 

the right return value for the polyfill should be  `["t", "e", "s", "t", "!"]` since a String object is an enumerable, the `Object.values` should return an array containing the given object's own enumerable property values.

source: [MDN](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_objects/Object/values)